### PR TITLE
anyRead() is now implicit

### DIFF
--- a/permissions.md
+++ b/permissions.md
@@ -139,7 +139,7 @@ A basic rule with a query template looks like this:
 template = "collection('public_messages')"
 ```
 
-The `list_messages` rule allows read operations on the `public_messages` table, such as:
+The `list_messages` rule allows read operations on the `public_messages` collection, such as:
 
 ```js
 horizon('public_messages').fetch()


### PR DESCRIPTION
The `anyRead()` placeholder is now implicitly appended to any read template that does not end in `.fetch()` or `.watch()`.
