### PR TITLE
hz init examples will require invalid database names

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -40,8 +40,8 @@ For more details, read the [Installation guide][ig].
 
 You can create a new Horizon app and start it as follows:
 
-    hz init my-app
-    hz serve my-app --dev
+    hz init my_app
+    hz serve my_app --dev
 
 For more details, see the [Getting Started][gs] guide.
 

--- a/getting-started.md
+++ b/getting-started.md
@@ -26,13 +26,13 @@ Interactions with Horizon are performed with the `hz` application. `hz` has a nu
 
 Let's create a new Horizon application. Go to a directory you'd like to install this application into and type:
 
-    hz init example-app
+    hz init example_app
 
-This will create the `example-app` directory and install a few files into it. (If you run `hz init` without giving it a directory, it will install these files into the current directory.)
+This will create the `example_app` directory and install a few files into it. (If you run `hz init` without giving it a directory, it will install these files into the current directory.)
 
 ```
-$ tree example-app
-example-app/
+$ tree example_app
+example_app/
 ├── .hz
 │   └── config.toml
 ├── dist
@@ -78,7 +78,7 @@ In production (i.e., without the `--dev` flag), you'll use the `.hz/config.toml`
 
 ## Talk to Horizon
 
-Load the `index.html` file in `example-app`. It's pretty short:
+Load the `index.html` file in `example_app`. It's pretty short:
 
 ```html
 <!doctype html>


### PR DESCRIPTION
Remove dashes from example project names to generate/require a valid database name