### PR TITLE
Fixing incomplete links in documentation

### DIFF
--- a/api/horizon.md
+++ b/api/horizon.md
@@ -51,7 +51,7 @@ query.subscribe(uuid => {
 });
 ```
 
-A `Horizon` object can be called as a function, taking a string as its argument. It returns a [Collection][c] object:
+A `Horizon` object can be called as a function, taking a string as its argument. It returns a [Collection][collection] object:
 
 ```js
 // Return the messages Collection
@@ -65,7 +65,7 @@ const messages = hz('messages');
 
 Establish a Horizon connection.
 
-Note that you can create a [Collection][c] from the `Horizon` instance without calling `connect()` first. Once you start using the collection, the connection will be automatically established.
+Note that you can create a [Collection][collection] from the `Horizon` instance without calling `connect()` first. Once you start using the collection, the connection will be automatically established.
 
 ```js
 const hz = Horizon();
@@ -137,6 +137,7 @@ template = "collection('users').find({id: userId()})"
 
 See [Permissions][perm] for more information on how to configure access rules, and [Authentication][auth] to find out how to configure user authentication on the Horizon server.
 
+[collection]: /api/collection
 [watch]: /api/collection/#watch
 [fetch]: /api/collection/#fetch
 [users]: /docs/users

--- a/getting-started.md
+++ b/getting-started.md
@@ -311,7 +311,7 @@ While Horizon serves static files from the `dist` folder by default, you can use
 * Use `horizon.js` served by the Horizon server
 * Install `@horizon/client` as a dependency in your project
 
-We recommend the first option, as that will prevent any possibly mismatches between the client library version and the Horizon server. However, if you're using [Webpack][] or a similar build setup, or requesting the `.js` library at load time isn't desirable, just add the client library as an NPM dependency (`npm install @horizon/client`).
+We recommend the first option, as that will prevent any possibly mismatches between the client library version and the Horizon server. However, if you're using [Webpack][webpack] or a similar build setup, or requesting the `.js` library at load time isn't desirable, just add the client library as an NPM dependency (`npm install @horizon/client`).
 
 In your application, you'll need to include the Horizon client file, and specify the Horizon port number when initializing the connection.
 


### PR DESCRIPTION
I have spent a lot of time in the docs these last few days and one thing that has been bothering me is that some of the links are incomplete/broken in the sense that they render something like `[Webpack][]`. 

It's a small problem, but it only took about 5 minutes to fix so I thought I would just do it.